### PR TITLE
Added ext-mbstring as dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     "require": {
         "php": ">= 5.6",
         "ext-bcmath": "*",
+        "ext-mbstring": "*",
         "symfony/event-dispatcher": "^2.7|^3.0",
         "graphaware/neo4j-common": "^2.0",
         "myclabs/php-enum": "^1.4"


### PR DESCRIPTION
Sorry, you were too fast to merge. You'll also need mbstring.
FYI, I used the standard docker php:7 container.
